### PR TITLE
Dynamic wallpaper size

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
 	</head>
 	<body>
 		<div id="container">
-			<canvas width="3840" height="2160"></canvas>
+			<!-- Empty size is set in JS -->
+			<canvas></canvas>
 			<p>
 				<!-- Empty links are set in JS -->
 				<a download="wallpaper.png" href="" id="download">Save this wallpaper</a>

--- a/wallpaper.js
+++ b/wallpaper.js
@@ -45,10 +45,12 @@ function generateValues( width ){
  * Draw the wallpaper onto the canvas, using values from the URL or a fresh set.
  */
 function draw(){
+	// Getting the size of the device screen to generate a wallpaper accordingly
+	const { width, height } = window.screen;
 	const canvas = document.querySelector( 'canvas' );
+	canvas.width = width;
+	canvas.height = height;
 	const ctx = canvas.getContext( '2d' );
-	const width = 3840;
-	const height = 2160;
 
 	const values = getDataFromUrl() ?? generateValues( width );
 	const {


### PR DESCRIPTION
## Description

In addition to the other UI/UX improvements I did today (#5), I tried to make the wallpaper engine adaptive to the device screen. This way, it can generated 16:10 wallpapers, instead of 16:9 ratio when needed, and it works for mobile too (though it might require a bit of tweaking with the values to make it a bit more relevant)! The only "down side" is that it won't be a "4K wallpaper generator" anymore, so it's up to you!

The advantage of this is that one "seed" can be used on desktop, and mobile, getting a similar result, but adapted to the screen size!

## Changes

- Removed default canvas size in HTML
- Determined wallpaper size based on Screen web API
- Updating canvas size based on screen size

## Result

Reference:

- Mobile: One plus 6T, 6.41", Firefox
- Desktop: Macbook Pro, 15", Firefox

### From mobile

![Screen Shot 2021-12-05 at 19 15 20](https://user-images.githubusercontent.com/19547331/144760309-fb297756-33c0-43b2-b6d7-8eb116ff32ff.png)

### To desktop

![Screenshot 2021-12-05 at 19-15-23 4K Desktop wallpaper generator](https://user-images.githubusercontent.com/19547331/144760314-67bf2ed4-5e4e-4b10-b17c-177c2ecee4e1.png)

### From desktop

![Screenshot 2021-12-05 at 19-13-50 4K Desktop wallpaper generator](https://user-images.githubusercontent.com/19547331/144760262-9bd5eaba-20e6-4989-bc8c-5628b7755a1a.png)

### To mobile

![Screen Shot 2021-12-05 at 19 14 20](https://user-images.githubusercontent.com/19547331/144760272-94a95c57-abf7-4c20-989e-52d4df205d12.png)
